### PR TITLE
Working example of Vagrant provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,25 +16,23 @@ Vagrant.configure(2) do |config|
   config.vm.define "manager" do |box|
     box.vm.network "private_network", ip: "192.168.50.10"
     box.vm.hostname = "mananger"
-
-    box.vm.provision "ansible" do |ansible|
-      ansible.playbook = "play.yml"
-      ansible.galaxy_role_file = "galaxy.roles"
-      ansible.groups = groups
-      #ansible.extra_vars = {
-      #  docker_swarm_interface: "eth1"
-      #}
-    end
   end
 
   (1..workers).each do |id|
     config.vm.define "worker-#{ id }" do |box|
       box.vm.network "private_network", ip: "192.168.50.#{ 10 + id }"
       box.vm.hostname = "worker-#{ id }"
-      box.vm.provision "ansible" do |ansible|
-        ansible.playbook = "play.yml"
-        ansible.galaxy_role_file = "galaxy.roles"
-        ansible.groups = groups
+      
+      if id == workers
+        box.vm.provision "ansible" do |ansible|
+          ansible.limit = "all" # Tell Vagrant not to limit ansible to this host
+          ansible.playbook = "play.yml"
+          ansible.galaxy_role_file = "requirements.yml"
+          ansible.groups = groups
+          ansible.extra_vars = {
+            docker_swarm_interface: "eth1"
+          }
+        end
       end
     end
   end

--- a/galaxy.roles
+++ b/galaxy.roles
@@ -1,1 +1,0 @@
-atosatto.docker-swarm

--- a/play.yml
+++ b/play.yml
@@ -2,6 +2,6 @@
 - hosts: all
   remote_user: root
   gather_facts: True
-  sudo: True
+  become: True
   roles:
   - atosatto.docker-swarm

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+- src: git@github.com:atosatto/ansible-dockerswarm.git 
+  scm: git
+  version: master
+  name: atosatto.docker-swarm


### PR DESCRIPTION
Ehi @djalexd, as a follow-up to https://github.com/atosatto/ansible-dockerswarm/issues/15, I've added in this PR some minor changes to your code in order to let the Vagrant + ansible-dockerswarm intregration work.

The most notable changes are:

- Implemented a workaround to trigger Ansible only when the last Virtualbox VM has been provisioned (for more reference see the "Tips and Tricks" section here https://www.vagrantup.com/docs/provisioning/ansible.html)
- Properly set the `docker_swarm_interface` variable in order to use the Vagrant private net to run the Swarm cluster commands and gossip protocol
- Removed some deprecation warnings using `become` for the privilege escalation and the yml galaxy dependencies format